### PR TITLE
Drop unstable requirement

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 #![allow(non_camel_case_types)]
 #![allow(improper_ctypes)]
-#![feature(untagged_unions)]
 extern crate libc;
 
 pub use api::*;


### PR DESCRIPTION
Untagged unions landed in stable Rust 1.19 (https://github.com/rust-lang/rust/pull/42068), which means this crate no longer needs `#![feature(untagged_unions)]`.