### PR TITLE
Always include `string.h`

### DIFF
--- a/libudis86/udis86.c
+++ b/libudis86/udis86.c
@@ -27,12 +27,7 @@
 #include "udint.h"
 #include "extern.h"
 #include "decode.h"
-
-#if !defined(__UD_STANDALONE__)
-# if HAVE_STRING_H
-#  include <string.h>
-# endif
-#endif /* !__UD_STANDALONE__ */
+#include <string.h>
 
 static void ud_inp_init(struct ud *u);
 

--- a/src/itab.rs
+++ b/src/itab.rs
@@ -934,6 +934,5 @@ pub enum ud_mnemonic_code {
 }
 
 extern "C" {
-    #[no_mangle]
     pub static mut ud_mnemonics_str: *mut *const libc::c_char;
 }


### PR DESCRIPTION
This always includes `string.h`, as I just ran into a compiler error where it suddenly does not work without this patch.
I also fixed a lint where you don't need to use `#[no_mangle]` anymore.